### PR TITLE
Update ModTags.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Fabric-Tutorial-1.17.1
-This fork of https://github.com/Tutorials-By-Kaupenjoe/Fabric-Tutorial-1.17.1 replaces use of the TagRegistry (deprecated) by making use of TagFactory instead.
+This fork of https://github.com/Tutorials-By-Kaupenjoe/Fabric-Tutorial-1.17.1 replaces use of the `TagRegistry` class (deprecated) by making use of `TagFactory` instead.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# Fabric-Tutorial-1.17.1
-This fork of https://github.com/Tutorials-By-Kaupenjoe/Fabric-Tutorial-1.17.1 replaces use of the `TagRegistry` class (deprecated) by making use of `TagFactory` instead.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Fabric-Tutorial-1.17.1
+This fork of https://github.com/Tutorials-By-Kaupenjoe/Fabric-Tutorial-1.17.1 replaces use of the TagRegistry (deprecated) by making use of TagFactory instead.

--- a/src/main/java/net/tutorialsbykaupenjoe/tutorialmod/util/ModTags.java
+++ b/src/main/java/net/tutorialsbykaupenjoe/tutorialmod/util/ModTags.java
@@ -1,6 +1,6 @@
 package net.tutorialsbykaupenjoe.tutorialmod.util;
 
-import net.fabricmc.fabric.api.tag.TagRegistry;
+import net.fabricmc.fabric.api.tag.TagFactory;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
@@ -12,11 +12,11 @@ public class ModTags {
         public static final Tag<Block> VALUABLE_BLOCKS = createTag("valuable_blocks");
 
         private static Tag<Block> createTag(String name) {
-            return TagRegistry.block(new Identifier(TutorialMod.MOD_ID, name));
+            return TagFactory.BLOCK.create(new Identifier(TutorialMod.MOD_ID, name));
         }
 
         private static Tag<Block> createCommonTag(String name) {
-            return TagRegistry.block(new Identifier("c", name));
+            return TagFactory.BLOCK.create(new Identifier("c", name));
         }
     }
 
@@ -26,11 +26,11 @@ public class ModTags {
         public static final Tag<Item> RUBIES = createCommonTag("rubies");
 
         private static Tag<Item> createTag(String name) {
-            return TagRegistry.item(new Identifier(TutorialMod.MOD_ID, name));
+            return TagFactory.ITEM.create(new Identifier(TutorialMod.MOD_ID, name));
         }
 
         private static Tag<Item> createCommonTag(String name) {
-            return TagRegistry.item(new Identifier("c", name));
+            return TagFactory.ITEM.create(new Identifier("c", name));
         }
     }
 }


### PR DESCRIPTION
Remove usage of deprecated class `TagRegistry`, using `TagFactory` instead.
Another change would be to change Tag<T> to Tag.Identified<T>. I have not tried this, it may be wrong.